### PR TITLE
refactor: add Env helper class for environment variables

### DIFF
--- a/src/Core.php
+++ b/src/Core.php
@@ -27,7 +27,6 @@ use function is_array;
 use function is_string;
 use function sprintf;
 
-use const FILTER_VALIDATE_BOOL;
 use const PHP_SESSION_ACTIVE;
 
 /**
@@ -234,9 +233,9 @@ final class Core
      */
     public static function getMode(): Mode
     {
-        $mode = $_SERVER['REX_MODE'] ?? $_ENV['REX_MODE'] ?? null;
+        $mode = Env::get('REX_MODE');
 
-        if (!is_string($mode) || '' === $mode) {
+        if (null === $mode) {
             return Mode::Live;
         }
 
@@ -296,7 +295,7 @@ final class Core
      */
     public static function isSafeModeForced(): bool
     {
-        return self::getBoolEnv('REX_SAFE_MODE');
+        return Env::getBool('REX_SAFE_MODE');
     }
 
     /**
@@ -307,13 +306,7 @@ final class Core
      */
     public static function getInstanceId(): string
     {
-        $id = $_SERVER['REX_INSTANCE_ID'] ?? $_ENV['REX_INSTANCE_ID'] ?? null;
-
-        if (!is_string($id) || '' === $id) {
-            throw new LogicException('The env var "REX_INSTANCE_ID" is missing, it must be defined in the ".env" file.');
-        }
-
-        return $id;
+        return Env::require('REX_INSTANCE_ID');
     }
 
     /**
@@ -322,16 +315,7 @@ final class Core
      */
     public static function getInstanceColor(): ?string
     {
-        $color = $_SERVER['REX_INSTANCE_COLOR'] ?? $_ENV['REX_INSTANCE_COLOR'] ?? null;
-
-        return is_string($color) && '' !== $color ? $color : null;
-    }
-
-    private static function getBoolEnv(string $name): bool
-    {
-        $value = $_SERVER[$name] ?? $_ENV[$name] ?? null;
-
-        return null !== $value && filter_var($value, FILTER_VALIDATE_BOOL);
+        return Env::get('REX_INSTANCE_COLOR');
     }
 
     /**
@@ -596,12 +580,6 @@ final class Core
             return array_map(static fn (mixed $value) => self::convertEnvVariables($value), $value);
         }
 
-        $value = $_SERVER[$var] ?? $_ENV[$var] ?? null;
-
-        if (null === $value) {
-            throw new InvalidArgumentException('Environment variable "' . $var . '" is not set.');
-        }
-
-        return $value;
+        return Env::get($var) ?? throw new InvalidArgumentException('Environment variable "' . $var . '" is not set.');
     }
 }

--- a/src/Env.php
+++ b/src/Env.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Redaxo\Core;
+
+use Redaxo\Core\Exception\LogicException;
+
+use function is_string;
+use function sprintf;
+
+use const FILTER_VALIDATE_BOOL;
+
+/**
+ * Access to environment variables (usually defined in the `.env` file).
+ *
+ * The variables are read from `$_SERVER` and `$_ENV`, in that order.
+ */
+final class Env
+{
+    private function __construct() {}
+
+    /**
+     * Returns the value of the env var, or `null` if it is not set or empty.
+     *
+     * @return non-empty-string|null
+     * @phpstan-impure
+     */
+    public static function get(string $name): ?string
+    {
+        $value = $_SERVER[$name] ?? $_ENV[$name] ?? null;
+
+        return is_string($value) && '' !== $value ? $value : null;
+    }
+
+    /**
+     * Returns the value of the env var and throws if it is not set or empty.
+     *
+     * @return non-empty-string
+     * @phpstan-impure
+     */
+    public static function require(string $name): string
+    {
+        return self::get($name) ?? throw new LogicException(sprintf('The env var "%s" is missing, it must be defined in the ".env" file.', $name));
+    }
+
+    /**
+     * Returns the value of the env var interpreted as boolean, e.g. `1`, `true`, `on` and `yes` are considered `true`.
+     *
+     * @phpstan-impure
+     */
+    public static function getBool(string $name): bool
+    {
+        return filter_var(self::get($name), FILTER_VALIDATE_BOOL);
+    }
+}

--- a/src/ErrorHandler.php
+++ b/src/ErrorHandler.php
@@ -25,7 +25,6 @@ use function defined;
 use function in_array;
 use function ini_get;
 use function is_array;
-use function is_string;
 use function Redaxo\Core\View\escape;
 use function sprintf;
 
@@ -364,9 +363,9 @@ final class ErrorHandler
      */
     public static function getThrowErrorLevels(): int
     {
-        $levels = $_SERVER['REX_ERROR_THROW'] ?? $_ENV['REX_ERROR_THROW'] ?? null;
+        $levels = Env::get('REX_ERROR_THROW');
 
-        if (!is_string($levels) || '' === $levels) {
+        if (null === $levels) {
             return Core::isDevMode() ? E_WARNING | E_NOTICE | E_USER_WARNING | E_USER_NOTICE : 0;
         }
 

--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -166,18 +166,6 @@ final class Request
     }
 
     /**
-     * Returns the variable $varname of $_ENV and casts the value.
-     *
-     * @param string $varname Variable name
-     * @param TCastType $type Cast type
-     * @param mixed $default Default value
-     */
-    public static function env(string $varname, string|array|Closure|null $type = null, mixed $default = ''): mixed
-    {
-        return self::arrayKeyCast($_ENV, $varname, $type, $default);
-    }
-
-    /**
      * Searches the value $needle in array $haystack and returns the casted value.
      *
      * @param array<mixed> $haystack Array

--- a/src/Runtime.php
+++ b/src/Runtime.php
@@ -37,7 +37,7 @@ class Runtime extends SymfonyRuntime
         // must be the live mode instead, so boot dotenv ourselves with that default before the parent runs.
         if (
             !($options['disable_dotenv'] ?? false) && isset($options['project_dir'])
-            && !isset($_SERVER[$envKey]) && !isset($_ENV[$envKey])
+            && null === Env::get($envKey)
             && class_exists(Dotenv::class)
         ) {
             new Dotenv($envKey, $debugKey)


### PR DESCRIPTION
Reading env vars was spread across `Core`, `ErrorHandler` and `Runtime`, each repeating the `$_SERVER[x] ?? $_ENV[x] ?? null` construct with its own handling of missing/empty values. More env vars are on the way, so this centralizes the access.

New class `Redaxo\Core\Env`:

- `get(string $name): ?string` — returns `non-empty-string|null`, reads `$_SERVER` then `$_ENV`
- `require(string $name): string` — throws a `LogicException` when unset or empty
- `getBool(string $name): bool`

Migrated: `Core::getMode()`, `getInstanceId()`, `getInstanceColor()`, `isSafeModeForced()` (the private `getBoolEnv()` is gone), `Core::convertEnvVariables()`, `ErrorHandler::getThrowErrorLevels()` and `Runtime::__construct()`. `Env` is now the only place in `src/` touching `$_ENV`.

`Request::env()` is removed: env vars are process environment, not request input, and mixing them with the tainted request superglobals is the wrong grouping. It also only read `$_ENV`, so it missed vars provided via `$_SERVER` — inconsistent with everything else in core. It was unused in this repo.

One behavior change: in `Runtime` an empty `REX_MODE` now counts as unset, so dotenv is booted and the `.env` file takes effect instead of silently falling back to live mode.