### PR TITLE
fix: skip the cronjob schedule lookup in the console

### DIFF
--- a/boot/core.php
+++ b/boot/core.php
@@ -126,7 +126,7 @@ if ('cli' !== PHP_SAPI && !Core::isSetup()) {
     }
 }
 
-$nexttime = Core::isSetup() || Core::getConsole() ? 0 : (int) Core::getConfig('cronjob_nexttime', 0);
+$nexttime = Core::isSetup() || 'cli' === PHP_SAPI ? 0 : (int) Core::getConfig('cronjob_nexttime', 0);
 if (0 !== $nexttime && time() >= $nexttime) {
     $env = CronjobExecutor::getCurrentEnvironment();
     $EP = 'backend' === $env ? 'PAGE_CHECKED' : 'PACKAGES_INCLUDED';


### PR DESCRIPTION
`boot/core.php` guards the cronjob schedule lookup with `Core::getConsole()`:

```php
$nexttime = Core::isSetup() || Core::getConsole() ? 0 : (int) Core::getConfig('cronjob_nexttime', 0);
```

That guard never triggers. The console application is registered in `boot/console.php`, which runs *after* `boot/core.php`, so `Core::getConsole()` is always null at that point. In 5.x the same check lives in the cronjob addon's boot file, where the console is already set — the guard broke when the logic moved into the core boot.

No cronjob actually ran in the console, but only by coincidence: `CronjobExecutor::getCurrentEnvironment()` resolves to `backend` there (`Core::getEnvironment()` falls back to the `redaxo` property for the same reason), and `PAGE_CHECKED` never fires in the console. What remained was a config lookup plus a dead listener on every command run, with the guarantee resting on two bugs cancelling each other out.

Verified by logging both the registration and the listener: before the change a console run logged `REGISTER sapi=cli env=backend ep=PAGE_CHECKED` (and no `FIRED`), afterwards it logs nothing, while a backend request still logs `REGISTER` and `FIRED`.

`PHP_SAPI` is checked instead, in line with the two other cli checks in the same file. Every cli entry point is the console, and `cronjob:run` defines `REX_CRONJOB_SCRIPT` itself when it runs the jobs explicitly, so nothing depends on this hook in the cli.