### PR TITLE
refactor!: normalize column types instead of simulating the display width

### DIFF
--- a/src/Database/Column.php
+++ b/src/Database/Column.php
@@ -4,32 +4,32 @@ namespace Redaxo\Core\Database;
 
 use Redaxo\Core\Exception\InvalidArgumentException;
 
+use function in_array;
 use function min;
 use function sprintf;
+use function strtolower;
 
 /**
  * Class to represent sql columns.
  */
 final class Column
 {
-    /**
-     * Default display width of the integer types, signed and unsigned.
-     *
-     * @var array<string, array{int, int}>
-     */
-    private const array INT_DISPLAY_WIDTHS = [
-        'tinyint' => [4, 3],
-        'smallint' => [6, 5],
-        'mediumint' => [9, 8],
-        'int' => [11, 10],
-        'bigint' => [20, 20],
+    private const array INTEGER_TYPES = ['tinyint', 'smallint', 'mediumint', 'int', 'bigint'];
+
+    /** Type names accepted as a synonym by the server, which reports the canonical name instead. */
+    private const array TYPE_ALIASES = [
+        'integer' => 'int',
+        'dec' => 'decimal',
+        'numeric' => 'decimal',
+        'fixed' => 'decimal',
+        'real' => 'double',
     ];
 
     private bool $modified = false;
 
     public function __construct(
         private string $name,
-        private string $type,
+        private string $type { set => self::normalizeType($value); },
         private bool $nullable = false,
         private ?string $default = null,
         private ?string $extra = null,
@@ -121,23 +121,11 @@ final class Column
         return new self($name, 'time' . self::fractionalSeconds($precision), $nullable, $default, null, $comment);
     }
 
-    /**
-     * Builds the type for an integer column, including its display width.
-     *
-     * @internal
-     */
-    public static function intType(string $type, bool $unsigned): string
-    {
-        [$signedWidth, $unsignedWidth] = self::INT_DISPLAY_WIDTHS[$type];
-
-        return $type . '(' . ($unsigned ? $unsignedWidth : $signedWidth) . ')' . ($unsigned ? ' unsigned' : '');
-    }
-
     private static function integer(string $type, string $name, bool $unsigned, bool $nullable, ?int $default, bool $autoIncrement, ?string $comment): self
     {
         return new self(
             $name,
-            self::intType($type, $unsigned),
+            $type . ($unsigned ? ' unsigned' : ''),
             $nullable,
             null === $default ? null : (string) $default,
             $autoIncrement ? 'auto_increment' : null,
@@ -194,7 +182,7 @@ final class Column
         return $this->setModified(true);
     }
 
-    /** @return string The column type, including its size, e.g. int(10) or varchar(255) */
+    /** @return string The normalized column type, e.g. `int unsigned` or `varchar(255)` */
     public function getType(): string
     {
         return $this->type;
@@ -260,6 +248,51 @@ final class Column
     }
 
     /**
+     * Normalizes a column type to the spelling that column comparison is based on.
+     *
+     * The display width of integer types is dropped, because it carries no meaning and MySQL stopped
+     * reporting it in 8.0.17 while MariaDB still does. `tinyint(1)` keeps it, as both engines report it
+     * and it is the idiomatic boolean type, and so do columns with `zerofill`, where the width decides
+     * how far a value is padded.
+     *
+     * @internal
+     */
+    public static function normalizeType(string $type): string
+    {
+        if (!preg_match('/^\s*(\w+)\s*(?:\(([^)]*)\))?\s*(.*?)\s*$/', $type, $match)) {
+            return $type;
+        }
+
+        $name = strtolower($match[1]);
+        $parameters = $match[2] ?? '';
+        $attributes = strtolower(preg_replace('/\s+/', ' ', $match[3]) ?? $match[3]);
+
+        if (in_array($name, ['bool', 'boolean'], true)) {
+            $name = 'tinyint';
+            $parameters = '1';
+        }
+
+        $name = self::TYPE_ALIASES[$name] ?? $name;
+
+        // Only numeric parameters may be reformatted, the values of `enum` and `set` must stay untouched.
+        if (preg_match('/^[\d\s,]*$/', $parameters)) {
+            $parameters = preg_replace('/\s+/', '', $parameters) ?? $parameters;
+        }
+
+        if (
+            in_array($name, self::INTEGER_TYPES, true)
+            && !str_contains($attributes, 'zerofill')
+            && !('tinyint' === $name && '1' === $parameters && '' === $attributes)
+        ) {
+            $parameters = '';
+        }
+
+        return $name
+            . ('' === $parameters ? '' : '(' . $parameters . ')')
+            . ('' === $attributes ? '' : ' ' . $attributes);
+    }
+
+    /**
      * Whether the default value is the current timestamp function instead of a literal value.
      *
      * @internal
@@ -297,6 +330,10 @@ final class Column
         // Since MySQL 8.0.13 an expression default value is reported as `DEFAULT_GENERATED`, which is
         // not part of a column definition and would break the generated SQL.
         $extra = preg_replace('/^DEFAULT_GENERATED\s*/i', '', $extra) ?? $extra;
+
+        if (0 === strcasecmp('auto_increment', $extra)) {
+            return 'auto_increment';
+        }
 
         return '' === $extra ? null : self::normalizeCurrentTimestamp($extra);
     }

--- a/src/Database/SchemaDumper.php
+++ b/src/Database/SchemaDumper.php
@@ -104,12 +104,8 @@ final readonly class SchemaDumper
 
             $method = 'bool';
             $default = null === $default ? null : ('1' === $default ? 'true' : 'false');
-        } elseif (preg_match('/^(tinyint|smallint|mediumint|int|bigint)\(\d+\)( unsigned)?$/', $type, $match)) {
+        } elseif (preg_match('/^(tinyint|smallint|mediumint|int|bigint)( unsigned)?$/', $type, $match)) {
             $unsigned = isset($match[2]);
-
-            if (Column::intType($match[1], $unsigned) !== $type) {
-                return null;
-            }
 
             if (null !== $default && !preg_match('/^-?\d+$/', $default)) {
                 return null;

--- a/src/Database/Table.php
+++ b/src/Database/Table.php
@@ -88,15 +88,7 @@ final class Table
         }
 
         foreach ($columns as $column) {
-            $type = $column['type'];
-
-            // Since MySQL 8.0.17 the display width for integer columns is deprecated and it is not
-            // reported anymore. To be compatible with our code for MySQL 5 and MariaDB we simulate
-            // the max display width. `tinyint(1)` and zerofill columns still report their width.
-            // https://dev.mysql.com/doc/refman/8.0/en/numeric-type-attributes.html
-            if (preg_match('/^(tinyint|smallint|mediumint|int|bigint)( unsigned)?$/', $type, $match)) {
-                $type = Column::intType($match[1], isset($match[2]));
-            }
+            $type = Column::normalizeType($column['type']);
 
             $default = $column['default'];
             if ("''" === $default && in_array($type, ['tinytext', 'text', 'mediumtext', 'longtext', 'tinyblob', 'blob', 'mediumblob', 'longblob'], true)) {

--- a/tests/Database/ColumnTest.php
+++ b/tests/Database/ColumnTest.php
@@ -10,6 +10,58 @@ use Redaxo\Core\Exception\InvalidArgumentException;
 /** @internal */
 final class ColumnTest extends TestCase
 {
+    #[DataProvider('provideTypes')]
+    public function testNormalizeType(string $expected, string $type): void
+    {
+        self::assertSame($expected, Column::normalizeType($type));
+        self::assertSame($expected, new Column('a', $type)->getType());
+        self::assertSame($expected, new Column('a', 'text')->setType($type)->getType());
+    }
+
+    /** @return iterable<string, array{string, string}> */
+    public static function provideTypes(): iterable
+    {
+        yield 'plain' => ['int', 'int'];
+        yield 'display width' => ['int', 'int(11)'];
+        yield 'non default display width' => ['int', 'int(5)'];
+        yield 'unsigned' => ['int unsigned', 'int(10) unsigned'];
+        yield 'bigint' => ['bigint unsigned', 'bigint(20) unsigned'];
+        yield 'tinyint' => ['tinyint', 'tinyint(4)'];
+
+        // The boolean type keeps its display width, both engines report it and clients rely on it.
+        yield 'boolean' => ['tinyint(1)', 'tinyint(1)'];
+        yield 'boolean unsigned' => ['tinyint unsigned', 'tinyint(1) unsigned'];
+
+        // With zerofill the display width decides how far a value is padded.
+        yield 'zerofill' => ['int(4) unsigned zerofill', 'int(4) unsigned zerofill'];
+
+        yield 'uppercase' => ['int unsigned', 'INT(10) UNSIGNED'];
+        yield 'surrounding whitespace' => ['varchar(255)', '  varchar(255)  '];
+        yield 'repeated whitespace' => ['int unsigned', 'int(10)   unsigned'];
+
+        yield 'alias integer' => ['int', 'integer'];
+        yield 'alias bool' => ['tinyint(1)', 'bool'];
+        yield 'alias boolean' => ['tinyint(1)', 'BOOLEAN'];
+        yield 'alias numeric' => ['decimal(10,2)', 'numeric(10,2)'];
+        yield 'alias dec' => ['decimal(10,2) unsigned', 'dec(10, 2) UNSIGNED'];
+        yield 'alias real' => ['double', 'real'];
+
+        yield 'decimal whitespace' => ['decimal(10,2)', 'decimal(10, 2)'];
+        yield 'datetime precision' => ['datetime(3)', 'datetime(3)'];
+        yield 'text' => ['mediumtext', 'MEDIUMTEXT'];
+
+        // Only the type name is case insensitive, the values of `enum` and `set` are not.
+        yield 'enum' => ["enum('A','b')", "enum('A','b')"];
+        yield 'set' => ["set('A','b')", "SET('A','b')"];
+    }
+
+    public function testEqualsIgnoresTypeSpelling(): void
+    {
+        self::assertTrue(new Column('a', 'int(10) unsigned')->equals(new Column('a', 'int unsigned')));
+        self::assertTrue(new Column('a', 'tinyint(1)')->equals(new Column('a', 'bool')));
+        self::assertFalse(new Column('a', 'int')->equals(new Column('a', 'int unsigned')));
+    }
+
     /** @param array{string, bool, string|null, string|null, string|null} $expected */
     #[DataProvider('provideFactories')]
     public function testFactory(array $expected, Column $column): void
@@ -30,14 +82,14 @@ final class ColumnTest extends TestCase
     /** @return iterable<string, array{array{string, bool, string|null, string|null, string|null}, Column}> */
     public static function provideFactories(): iterable
     {
-        yield 'int' => [['int(11)', false, null, null, null], Column::int('a')];
-        yield 'int unsigned' => [['int(10) unsigned', false, null, null, null], Column::int('a', unsigned: true)];
-        yield 'int auto increment' => [['int(10) unsigned', false, null, 'auto_increment', null], Column::int('a', unsigned: true, autoIncrement: true)];
-        yield 'int with default' => [['int(11)', true, '-5', null, 'c'], Column::int('a', nullable: true, default: -5, comment: 'c')];
-        yield 'tinyint' => [['tinyint(4)', false, '0', null, null], Column::tinyint('a', default: 0)];
-        yield 'smallint unsigned' => [['smallint(5) unsigned', false, null, null, null], Column::smallint('a', unsigned: true)];
-        yield 'mediumint' => [['mediumint(9)', false, null, null, null], Column::mediumint('a')];
-        yield 'bigint unsigned' => [['bigint(20) unsigned', false, null, null, null], Column::bigint('a', unsigned: true)];
+        yield 'int' => [['int', false, null, null, null], Column::int('a')];
+        yield 'int unsigned' => [['int unsigned', false, null, null, null], Column::int('a', unsigned: true)];
+        yield 'int auto increment' => [['int unsigned', false, null, 'auto_increment', null], Column::int('a', unsigned: true, autoIncrement: true)];
+        yield 'int with default' => [['int', true, '-5', null, 'c'], Column::int('a', nullable: true, default: -5, comment: 'c')];
+        yield 'tinyint' => [['tinyint', false, '0', null, null], Column::tinyint('a', default: 0)];
+        yield 'smallint unsigned' => [['smallint unsigned', false, null, null, null], Column::smallint('a', unsigned: true)];
+        yield 'mediumint' => [['mediumint', false, null, null, null], Column::mediumint('a')];
+        yield 'bigint unsigned' => [['bigint unsigned', false, null, null, null], Column::bigint('a', unsigned: true)];
 
         yield 'bool' => [['tinyint(1)', false, null, null, null], Column::bool('a')];
         yield 'bool true' => [['tinyint(1)', false, '1', null, null], Column::bool('a', default: true)];
@@ -115,6 +167,7 @@ final class ColumnTest extends TestCase
     {
         yield 'null' => [null, null];
         yield 'auto increment' => ['auto_increment', 'auto_increment'];
+        yield 'auto increment uppercase' => ['auto_increment', 'AUTO_INCREMENT'];
         yield 'mysql spelling' => ['on update CURRENT_TIMESTAMP', 'on update CURRENT_TIMESTAMP'];
         yield 'mariadb spelling' => ['on update CURRENT_TIMESTAMP', 'on update current_timestamp()'];
         yield 'with precision' => ['on update CURRENT_TIMESTAMP(3)', 'on update current_timestamp(3)'];

--- a/tests/Database/TableTest.php
+++ b/tests/Database/TableTest.php
@@ -79,7 +79,7 @@ final class TableTest extends TestCase
 
         self::assertInstanceOf(Column::class, $id);
         self::assertSame('id', $id->getName());
-        self::assertSame('int(11)', $id->getType());
+        self::assertSame('int', $id->getType());
         self::assertFalse($id->isNullable());
         self::assertNull($id->getDefault());
         self::assertSame('auto_increment', $id->getExtra());
@@ -282,7 +282,7 @@ final class TableTest extends TestCase
             // In MySQL 8 the display width of integers is simulated by Table class to the max width.
             self::assertEquals('int(11)', $table->getColumn('amount')?->getType());
         } else {
-            self::assertEquals('int(5)', $table->getColumn('amount')?->getType());
+            self::assertEquals('int', $table->getColumn('amount')?->getType());
         }
     }
 
@@ -295,7 +295,7 @@ final class TableTest extends TestCase
 
         $id = $table->getColumn('id');
         self::assertInstanceOf(Column::class, $id);
-        self::assertSame('int(10) unsigned', $id->getType());
+        self::assertSame('int unsigned', $id->getType());
         self::assertFalse($id->isNullable());
         self::assertNull($id->getDefault());
         self::assertSame('auto_increment', $id->getExtra());
@@ -609,7 +609,7 @@ final class TableTest extends TestCase
     {
         $table = $this->createTable();
 
-        $table->getColumn('id')->setType('int(10) unsigned');
+        $table->getColumn('id')->setType('int unsigned');
         $table
             ->setName(self::TABLE2)
             ->removeColumn('title')
@@ -625,7 +625,7 @@ final class TableTest extends TestCase
         self::assertFalse($table->hasIndex('i_title'));
         self::assertTrue($table->hasColumn('name'));
         self::assertTrue($table->hasIndex('i_name'));
-        self::assertSame('int(10) unsigned', $table->getColumn('id')?->getType());
+        self::assertSame('int unsigned', $table->getColumn('id')?->getType());
         self::assertEquals(['id', 'name'], $table->getPrimaryKey());
         self::assertEquals(['name'], $table->getIndex('i_name')?->getColumns());
     }
@@ -712,11 +712,12 @@ final class TableTest extends TestCase
     public static function provideIntegerTypes(): iterable
     {
         $types = [
-            'tinyint(4)', 'tinyint(3) unsigned', 'tinyint(1)',
-            'smallint(6)', 'smallint(5) unsigned',
-            'mediumint(9)', 'mediumint(8) unsigned',
-            'int(11)', 'int(10) unsigned',
-            'bigint(20)', 'bigint(20) unsigned',
+            'tinyint(4)', 'tinyint(3) unsigned', 'tinyint(1)', 'tinyint', 'tinyint unsigned',
+            'smallint(6)', 'smallint(5) unsigned', 'smallint', 'smallint unsigned',
+            'mediumint(9)', 'mediumint(8) unsigned', 'mediumint', 'mediumint unsigned',
+            'int(11)', 'int(10) unsigned', 'int', 'int unsigned', 'int(5)',
+            'bigint(20)', 'bigint(20) unsigned', 'bigint', 'bigint unsigned',
+            'int(4) unsigned zerofill',
         ];
 
         foreach ($types as $type) {

--- a/tests/Database/TableTest.php
+++ b/tests/Database/TableTest.php
@@ -277,13 +277,8 @@ final class TableTest extends TestCase
 
         self::assertEquals($status, $table->getColumn('status'));
 
-        $sql = Sql::factory();
-        if (Sql::MYSQL === $sql->getDbType() && 8 <= (int) $sql->getDbVersion()) {
-            // In MySQL 8 the display width of integers is simulated by Table class to the max width.
-            self::assertEquals('int(11)', $table->getColumn('amount')?->getType());
-        } else {
-            self::assertEquals('int', $table->getColumn('amount')?->getType());
-        }
+        // The display width is normalized away, so the type does not depend on the database engine.
+        self::assertEquals('int', $table->getColumn('amount')?->getType());
     }
 
     public function testEnsurePrimaryIdColumn(): void


### PR DESCRIPTION
Follow-up to #6638.

Reading a table simulated the display width of integer columns, because MySQL stopped reporting it in 8.0.17 while MariaDB still does. That required a table of hardcoded widths per type and per signedness:

```php
private const array INT_DISPLAY_WIDTHS = [
    'tinyint' => [4, 3], 'smallint' => [6, 5], 'mediumint' => [9, 8], 'int' => [11, 10], 'bigint' => [20, 20],
];
```

And it only ever normalized one side. A definition written as `int` never matched a column that MariaDB reports as `int(11)`, so that column was altered on every `ensure()` call — the same class of bug as the `AUTO_INCREMENT` spelling fixed in #6638.

### What changed

The normalization is inverted and moved into `Column`, applied through a property hook so that database reads and user supplied types go through the same path and it cannot be bypassed:

```php
private string $type { set => self::normalizeType($value); },
```

The display width is dropped. It carries no meaning, and the widthless spelling is the only one both engines round trip identically: we write `int`, MariaDB stores `int(11)` and reports it back, we normalize to `int` again. On MySQL 8 it additionally stops us from emitting DDL that triggers a deprecation warning.

Two exceptions keep their width:

- **`tinyint(1)`** — reported by both engines, and the idiomatic boolean type that clients detect. Stripping it would turn new boolean columns into `tinyint(4)`.
- **`zerofill`** — there the width decides how far a value is padded, so it is significant.

Note that `tinyint(1) unsigned` does *not* keep its width. Stripping is the safe choice cross-engine: MariaDB reports `tinyint(1) unsigned`, and stripping matches whether or not MySQL preserves the width there.

Since the type is normalized on write, existing definitions keep working — `int(10) unsigned` and `int unsigned` describe the same column. The same pass also normalizes the spelling, so these no longer differ from what the server reports:

| written | normalized |
| --- | --- |
| `INT(10) UNSIGNED` | `int unsigned` |
| `integer` | `int` |
| `bool`, `BOOLEAN` | `tinyint(1)` |
| `numeric(10, 2)`, `dec(10,2)` | `decimal(10,2)` |
| `real` | `double` |

Only the type name and its attributes are case insensitive — the values of `enum` and `set` are left untouched. `auto_increment` is now normalized case insensitively too, which fixes the same mismatch for anyone using the constructor rather than a factory method.

### Impact

**No migration needed.** Against an existing database full of `int(10) unsigned` columns, `console migrate` issues zero schema statements (verified with the MariaDB query log). Because #6638 moved the call sites to factory methods, neither `setup/install.php` nor the MetaInfo fields are touched by this PR at all — the representation is entirely behind `Column`.

**Breaking:** `Column::getType()` returns the normalized type, so code comparing it against a literal like `'int(10) unsigned'` needs updating. `Column::intType()`, added in #6638 and marked `@internal`, is gone.

### Verification

`TableTest::provideIntegerTypes` now round trips 23 spellings against a real database — every integer type signed and unsigned, with and without width, plus `tinyint(1)` and a zerofill column. Each is written, read back and compared as a `Column` object, which exercises the emitted DDL as well as the read path. `ColumnTest` covers `normalizeType()` directly, including that the constructor and `setType()` both apply it.

Emitted DDL for a fresh table:

```sql
CREATE TABLE `rex_widthless_demo` (
  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,   -- we wrote `int unsigned`
  `active` tinyint(1) NOT NULL,                    -- boolean marker preserved
  `counter` bigint(20) unsigned NOT NULL,          -- we wrote `bigint unsigned`
  `title` varchar(191) NOT NULL,
  PRIMARY KEY (`id`)
)
```