### PR TITLE
refactor!: move the accesskeys into a `Backend\Accesskey` class

### DIFF
--- a/boot/backend.php
+++ b/boot/backend.php
@@ -1,6 +1,7 @@
 <?php
 
 use Redaxo\Core\ApiFunction\ApiFunction;
+use Redaxo\Core\Backend\Accesskey;
 use Redaxo\Core\Backend\Appearance;
 use Redaxo\Core\Backend\Controller;
 use Redaxo\Core\Backend\Style;
@@ -225,7 +226,7 @@ Asset::addJsFile(Url::coreAssets('clipboard-copy-element.js'), [Asset::JS_IMMUTA
 Asset::addJsFile(Url::coreAssets('js/mediapool.js'), [Asset::JS_IMMUTABLE]);
 
 Asset::setJsProperty('backend', true);
-Asset::setJsProperty('accesskeys', Core::getProperty('use_accesskeys'));
+Asset::setJsProperty('accesskeys', Accesskey::$enabled);
 Asset::setJsProperty('cookie_params', Login::getCookieParams());
 
 if (Core::getUser()) {

--- a/pages/mediapool/media.list.php
+++ b/pages/mediapool/media.list.php
@@ -1,6 +1,7 @@
 <?php
 
 use Redaxo\Core\ApiFunction\Exception\ApiFunctionException;
+use Redaxo\Core\Backend\Accesskey;
 use Redaxo\Core\Backend\Controller;
 use Redaxo\Core\Core;
 use Redaxo\Core\Database\Sql;
@@ -217,7 +218,7 @@ $panel .= '
         <table class="table table-striped table-hover">
             <thead>
             <tr>
-                <th class="rex-table-icon"><a class="rex-link-expanded" href="' . Url::backendController(array_merge(['page' => 'mediapool/upload'], $argUrl)) . '"' . Core::getAccesskey(I18n::msg('pool_file_insert'), 'add') . ' title="' . I18n::msg('pool_file_insert') . '"><i class="rex-icon rex-icon-add-media"></i></a></th>
+                <th class="rex-table-icon"><a class="rex-link-expanded" href="' . Url::backendController(array_merge(['page' => 'mediapool/upload'], $argUrl)) . '"' . Accesskey::attributes(I18n::msg('pool_file_insert'), 'add') . ' title="' . I18n::msg('pool_file_insert') . '"><i class="rex-icon rex-icon-add-media"></i></a></th>
                 <th class="rex-table-thumbnail">' . I18n::msg('pool_file_thumbnail') . '</th>
                 <th>' . I18n::msg('pool_file_info') . ' / ' . I18n::msg('pool_file_description') . '</th>
                 <th>' . I18n::msg('pool_last_update') . '</th>

--- a/pages/mediapool/media.list.php
+++ b/pages/mediapool/media.list.php
@@ -218,7 +218,7 @@ $panel .= '
         <table class="table table-striped table-hover">
             <thead>
             <tr>
-                <th class="rex-table-icon"><a class="rex-link-expanded" href="' . Url::backendController(array_merge(['page' => 'mediapool/upload'], $argUrl)) . '"' . Accesskey::attributes(I18n::msg('pool_file_insert'), 'add') . ' title="' . I18n::msg('pool_file_insert') . '"><i class="rex-icon rex-icon-add-media"></i></a></th>
+                <th class="rex-table-icon"><a class="rex-link-expanded" href="' . Url::backendController(array_merge(['page' => 'mediapool/upload'], $argUrl)) . '"' . Accesskey::attributes(I18n::msg('pool_file_insert'), 'add') . '><i class="rex-icon rex-icon-add-media"></i></a></th>
                 <th class="rex-table-thumbnail">' . I18n::msg('pool_file_thumbnail') . '</th>
                 <th>' . I18n::msg('pool_file_info') . ' / ' . I18n::msg('pool_file_description') . '</th>
                 <th>' . I18n::msg('pool_last_update') . '</th>

--- a/pages/mediapool/structure.php
+++ b/pages/mediapool/structure.php
@@ -1,6 +1,6 @@
 <?php
 
-use Redaxo\Core\Core;
+use Redaxo\Core\Backend\Accesskey;
 use Redaxo\Core\Exception\UserMessageException;
 use Redaxo\Core\Filesystem\Url;
 use Redaxo\Core\Http\Request;
@@ -108,7 +108,7 @@ if ($PERMALL) {
         <table class="table table-striped table-hover">
             <thead>
                 <tr>
-                    <th class="rex-table-icon"><a class="rex-link-expanded" href="' . $link . $catId . '&amp;media_method=add_cat"' . Core::getAccesskey(I18n::msg('pool_kat_create'), 'add') . ' title="' . I18n::msg('pool_kat_create') . '"><i class="rex-icon rex-icon-add-media-category"></i></a></th>
+                    <th class="rex-table-icon"><a class="rex-link-expanded" href="' . $link . $catId . '&amp;media_method=add_cat"' . Accesskey::attributes(I18n::msg('pool_kat_create'), 'add') . ' title="' . I18n::msg('pool_kat_create') . '"><i class="rex-icon rex-icon-add-media-category"></i></a></th>
                     <th class="rex-table-id">' . I18n::msg('id') . '</th>
                     <th>' . I18n::msg('pool_kat_name') . '</th>
                     <th class="rex-table-action" colspan="2">' . I18n::msg('pool_kat_function') . '</th>
@@ -123,7 +123,7 @@ if ($PERMALL) {
                 <td class="rex-table-id" data-title="' . I18n::msg('id') . '">-</td>
                 <td data-title="' . I18n::msg('pool_kat_name') . '"><input class="form-control" type="text" name="catname" value="" autofocus /></td>
                 <td class="rex-table-action" colspan="2">
-                    <button class="btn btn-save" type="submit" value="' . I18n::msg('pool_kat_create') . '"' . Core::getAccesskey(I18n::msg('pool_kat_create'), 'save') . '>' . I18n::msg('pool_kat_create') . '</button>
+                    <button class="btn btn-save" type="submit" value="' . I18n::msg('pool_kat_create') . '"' . Accesskey::attributes(I18n::msg('pool_kat_create'), 'save') . '>' . I18n::msg('pool_kat_create') . '</button>
                 </td>
             </tr>
         ';
@@ -141,7 +141,7 @@ if ($PERMALL) {
                     <td data-title="' . I18n::msg('pool_kat_name') . '"><input class="form-control" type="text" name="cat_name" value="' . escape($iname) . '" autofocus /></td>
                     <td class="rex-table-action" colspan="2">
                         <input type="hidden" name="edit_id" value="' . $editId . '" />
-                        <button class="btn btn-save" type="submit" value="' . I18n::msg('pool_kat_update') . '"' . Core::getAccesskey(I18n::msg('pool_kat_update'), 'save') . '>' . I18n::msg('pool_kat_update') . '</button>
+                        <button class="btn btn-save" type="submit" value="' . I18n::msg('pool_kat_update') . '"' . Accesskey::attributes(I18n::msg('pool_kat_update'), 'save') . '>' . I18n::msg('pool_kat_update') . '</button>
                     </td>
                 </tr>
             ';

--- a/pages/mediapool/structure.php
+++ b/pages/mediapool/structure.php
@@ -108,7 +108,7 @@ if ($PERMALL) {
         <table class="table table-striped table-hover">
             <thead>
                 <tr>
-                    <th class="rex-table-icon"><a class="rex-link-expanded" href="' . $link . $catId . '&amp;media_method=add_cat"' . Accesskey::attributes(I18n::msg('pool_kat_create'), 'add') . ' title="' . I18n::msg('pool_kat_create') . '"><i class="rex-icon rex-icon-add-media-category"></i></a></th>
+                    <th class="rex-table-icon"><a class="rex-link-expanded" href="' . $link . $catId . '&amp;media_method=add_cat"' . Accesskey::attributes(I18n::msg('pool_kat_create'), 'add') . '><i class="rex-icon rex-icon-add-media-category"></i></a></th>
                     <th class="rex-table-id">' . I18n::msg('id') . '</th>
                     <th>' . I18n::msg('pool_kat_name') . '</th>
                     <th class="rex-table-action" colspan="2">' . I18n::msg('pool_kat_function') . '</th>

--- a/pages/profile/index.php
+++ b/pages/profile/index.php
@@ -1,6 +1,7 @@
 <?php
 
 use Redaxo\Core\ApiFunction\ApiFunction;
+use Redaxo\Core\Backend\Accesskey;
 use Redaxo\Core\Backend\Appearance;
 use Redaxo\Core\Core;
 use Redaxo\Core\Database\Sql;
@@ -271,7 +272,7 @@ $content .= '</fieldset>';
 $formElements = [];
 
 $n = [];
-$n['field'] = '<button class="btn btn-save rex-form-aligned" type="submit" value="1" name="upd_profile_button" ' . Core::getAccesskey(I18n::msg('profile_save'), 'save') . '>' . I18n::msg('profile_save') . '</button>';
+$n['field'] = '<button class="btn btn-save rex-form-aligned" type="submit" value="1" name="upd_profile_button" ' . Accesskey::attributes(I18n::msg('profile_save'), 'save') . '>' . I18n::msg('profile_save') . '</button>';
 $formElements[] = $n;
 
 $fragment = new Fragment();
@@ -348,7 +349,7 @@ $content .= '</fieldset>';
 $formElements = [];
 
 $n = [];
-$n['field'] = '<button class="btn btn-save rex-form-aligned" type="submit" value="1" name="upd_psw_button" ' . Core::getAccesskey(I18n::msg('profile_save_psw'), 'save') . '>' . I18n::msg('profile_save_psw') . '</button>';
+$n['field'] = '<button class="btn btn-save rex-form-aligned" type="submit" value="1" name="upd_psw_button" ' . Accesskey::attributes(I18n::msg('profile_save_psw'), 'save') . '>' . I18n::msg('profile_save_psw') . '</button>';
 $formElements[] = $n;
 
 $fragment = new Fragment();
@@ -369,7 +370,7 @@ $content .= '</fieldset>';
 $formElements = [];
 
 $n = [];
-$n['field'] = '<button class="btn btn-save rex-form-aligned" type="submit" value="1" name="add_passkey" ' . Core::getAccesskey(I18n::msg('passkey_add'), 'save') . '>' . I18n::msg('passkey_add') . '</button>';
+$n['field'] = '<button class="btn btn-save rex-form-aligned" type="submit" value="1" name="add_passkey" ' . Accesskey::attributes(I18n::msg('passkey_add'), 'save') . '>' . I18n::msg('passkey_add') . '</button>';
 $formElements[] = $n;
 
 $fragment = new Fragment();

--- a/pages/structure/content.metainfo.php
+++ b/pages/structure/content.metainfo.php
@@ -1,5 +1,6 @@
 <?php
 
+use Redaxo\Core\Backend\Accesskey;
 use Redaxo\Core\Backend\Controller;
 use Redaxo\Core\Content\ApiFunction\ArticleStatusChange;
 use Redaxo\Core\Content\Article;
@@ -139,7 +140,7 @@ if (1 == $article->getRows()) {
                         <input type="hidden" name="ctype" value="' . $ctype . '" />
                         ' . $csrfToken->getHiddenField() . '
                         ' . $form . '
-                        <button class="btn btn-primary pull-left" type="submit" name="savemeta"' . Core::getAccesskey(I18n::msg('update_metadata'), 'save') . ' value="1">' . I18n::msg('update_metadata') . '</button>
+                        <button class="btn btn-primary pull-left" type="submit" name="savemeta"' . Accesskey::attributes(I18n::msg('update_metadata'), 'save') . ' value="1">' . I18n::msg('update_metadata') . '</button>
                     </fieldset>
                 </form>
               </div>

--- a/pages/structure/index.php
+++ b/pages/structure/index.php
@@ -1,6 +1,7 @@
 <?php
 
 use Redaxo\Core\ApiFunction\ApiFunction;
+use Redaxo\Core\Backend\Accesskey;
 use Redaxo\Core\Content\ApiFunction\ArticleAdd;
 use Redaxo\Core\Content\ApiFunction\ArticleDelete;
 use Redaxo\Core\Content\ApiFunction\ArticleEdit;
@@ -86,7 +87,7 @@ if ($category) {
 
 $addCategory = '';
 if ($user->hasPerm('addCategory[]') && $structureContext->hasCategoryPermission()) {
-    $addCategory = '<a class="rex-link-expanded" href="' . $structureContext->getContext()->getUrl(['function' => 'add_cat', 'catstart' => $structureContext->catStart]) . '"' . Core::getAccesskey(I18n::msg('add_category'), 'add') . '><i class="rex-icon rex-icon-add-category"></i></a>';
+    $addCategory = '<a class="rex-link-expanded" href="' . $structureContext->getContext()->getUrl(['function' => 'add_cat', 'catstart' => $structureContext->catStart]) . '"' . Accesskey::attributes(I18n::msg('add_category'), 'add') . '><i class="rex-icon rex-icon-add-category"></i></a>';
 }
 
 $dataColspan = 5;
@@ -168,7 +169,7 @@ if ('add_cat' === $structureContext->function && $user->hasPerm('addCategory[]')
     ]));
     $addButtons = CategoryAdd::getHiddenFields() . '
         <input type="hidden" name="parent-category-id" value="' . $structureContext->categoryId . '" />
-        <button class="btn btn-save" type="submit" name="category-add-button"' . Core::getAccesskey(I18n::msg('add_category'), 'save') . '>' . I18n::msg('add_category') . '</button>';
+        <button class="btn btn-save" type="submit" name="category-add-button"' . Accesskey::attributes(I18n::msg('add_category'), 'save') . '>' . I18n::msg('add_category') . '</button>';
 
     $class = 'mark';
 
@@ -238,7 +239,7 @@ if ($KAT->getRows() > 0) {
 
                 $addButtons = CategoryEdit::getHiddenFields() . '
                 <input type="hidden" name="category-id" value="' . $structureContext->editId . '" />
-                <button class="btn btn-save" type="submit" name="category-edit-button"' . Core::getAccesskey(I18n::msg('save_category'), 'save') . '>' . I18n::msg('save_category') . '</button>';
+                <button class="btn btn-save" type="submit" name="category-edit-button"' . Accesskey::attributes(I18n::msg('save_category'), 'save') . '>' . I18n::msg('save_category') . '</button>';
 
                 $class = 'mark';
                 if ('' != $metaButtons) {
@@ -353,7 +354,7 @@ if ($structureContext->categoryId > 0 || (0 === $structureContext->categoryId &&
     // --------------------- ARTIKEL LIST
     $artAddLink = '';
     if ($user->hasPerm('addArticle[]') && $structureContext->hasCategoryPermission()) {
-        $artAddLink = '<a class="rex-link-expanded" href="' . $structureContext->getContext()->getUrl(['function' => 'add_art', 'artstart' => $structureContext->artStart]) . '"' . Core::getAccesskey(I18n::msg('article_add'), 'add_2') . '><i class="rex-icon rex-icon-add-article"></i></a>';
+        $artAddLink = '<a class="rex-link-expanded" href="' . $structureContext->getContext()->getUrl(['function' => 'add_art', 'artstart' => $structureContext->artStart]) . '"' . Accesskey::attributes(I18n::msg('article_add'), 'add_2') . '><i class="rex-icon rex-icon-add-article"></i></a>';
     }
 
     $articleOrderBy = Extension::dispatch(new ExtensionPoint('PAGE_STRUCTURE_ARTICLE_ORDER_BY', 'priority, name', [
@@ -442,7 +443,7 @@ if ($structureContext->categoryId > 0 || (0 === $structureContext->categoryId &&
                     ' . $tmplTd . '
                     <td class="rex-table-date" data-title="' . I18n::msg('header_date') . '">' . Formatter::intlDate(time()) . '</td>
                     <td class="rex-table-priority" data-title="' . I18n::msg('header_priority') . '"><input class="form-control" type="number" name="article-position" value="' . ($artPager->getRowCount() + 1) . '" required min="1" inputmode="numeric" /></td>
-                    <td class="rex-table-action" colspan="' . $colspan . '">' . ArticleAdd::getHiddenFields() . '<button class="btn btn-save" type="submit" name="artadd_function"' . Core::getAccesskey(I18n::msg('article_add'), 'save') . '>' . I18n::msg('article_add') . '</button></td>
+                    <td class="rex-table-action" colspan="' . $colspan . '">' . ArticleAdd::getHiddenFields() . '<button class="btn btn-save" type="submit" name="artadd_function"' . Accesskey::attributes(I18n::msg('article_add'), 'save') . '>' . I18n::msg('article_add') . '</button></td>
                 </tr>
                             ';
     } elseif (0 === $sql->getRows()) {
@@ -487,7 +488,7 @@ if ($structureContext->categoryId > 0 || (0 === $structureContext->categoryId &&
                             ' . $tmplTd . '
                             <td class="rex-table-date" data-title="' . I18n::msg('header_date') . '">' . Formatter::intlDate($sql->getDateTimeValue('createdate')) . '</td>
                             <td class="rex-table-priority" data-title="' . I18n::msg('header_priority') . '"><input class="form-control" type="number" name="article-position" value="' . escape($sql->getValue('priority')) . '" required min="1" inputmode="numeric" /></td>
-                            <td class="rex-table-action" colspan="' . $colspan . '">' . ArticleEdit::getHiddenFields() . '<button class="btn btn-save" type="submit" name="artedit_function"' . Core::getAccesskey(I18n::msg('article_save'), 'save') . '>' . I18n::msg('article_save') . '</button></td>
+                            <td class="rex-table-action" colspan="' . $colspan . '">' . ArticleEdit::getHiddenFields() . '<button class="btn btn-save" type="submit" name="artedit_function"' . Accesskey::attributes(I18n::msg('article_save'), 'save') . '>' . I18n::msg('article_save') . '</button></td>
                         </tr>';
         } elseif ($structureContext->hasCategoryPermission()) {
             // --------------------- ARTIKEL NORMAL VIEW | EDIT AND ENTER

--- a/pages/system/clangs.php
+++ b/pages/system/clangs.php
@@ -1,5 +1,6 @@
 <?php
 
+use Redaxo\Core\Backend\Accesskey;
 use Redaxo\Core\Core;
 use Redaxo\Core\Database\Sql;
 use Redaxo\Core\Exception\UserMessageException;
@@ -106,7 +107,7 @@ $content .= '
         <table class="table table-striped table-hover">
             <thead>
                 <tr>
-                    <th class="rex-table-icon"><a class="rex-link-expanded" href="' . Url::currentBackendPage(['func' => 'addclang']) . '#clang"' . Core::getAccesskey(I18n::msg('clang_add'), 'add') . '><i class="rex-icon rex-icon-add-language"></i></a></th>
+                    <th class="rex-table-icon"><a class="rex-link-expanded" href="' . Url::currentBackendPage(['func' => 'addclang']) . '#clang"' . Accesskey::attributes(I18n::msg('clang_add'), 'add') . '><i class="rex-icon rex-icon-add-language"></i></a></th>
                     <th class="rex-table-id">' . I18n::msg('id') . '</th>
                     <th>' . I18n::msg('clang_code') . '</th>
                     <th>' . I18n::msg('clang_name') . '</th>
@@ -131,7 +132,7 @@ if ('addclang' == $func) {
                     <td data-title="' . I18n::msg('clang_name') . '"><input class="form-control" type="text" id="rex-form-clang-name" name="clang_name" value="' . escape($clangName) . '" required maxlength="255" /></td>
                     <td class="rex-table-priority" data-title="' . I18n::msg('clang_priority') . '"><input class="form-control" type="number" id="rex-form-clang-prio" name="clang_prio" value="' . ($clangPrio ?: Language::count() + 1) . '" required min="1" inputmode="numeric" /></td>
                     <td class="rex-table-action">' . $metaButtons . '</td>
-                    <td class="rex-table-action" colspan="2"><button class="btn btn-save" type="submit" name="add_clang_save"' . Core::getAccesskey(I18n::msg('clang_add'), 'save') . ' value="1">' . I18n::msg('clang_add') . '</button></td>
+                    <td class="rex-table-action" colspan="2"><button class="btn btn-save" type="submit" name="add_clang_save"' . Accesskey::attributes(I18n::msg('clang_add'), 'save') . ' value="1">' . I18n::msg('clang_add') . '</button></td>
                 </tr>
             ';
 
@@ -164,7 +165,7 @@ foreach ($sql as $row) {
                         <td data-title="' . I18n::msg('clang_name') . '"><input class="form-control" type="text" id="rex-form-clang-name" name="clang_name" value="' . escape($sql->getValue('name')) . '" required maxlength="255" /></td>
                         <td class="rex-table-priority" data-title="' . I18n::msg('clang_priority') . '"><input class="form-control" type="number" id="rex-form-clang-prio" name="clang_prio" value="' . escape($sql->getValue('priority')) . '" required min="1" inputmode="numeric" /></td>
                         <td class="rex-table-action">' . $metaButtons . '</td>
-                        <td class="rex-table-action" colspan="2"><button class="btn btn-save" type="submit" name="edit_clang_save"' . Core::getAccesskey(I18n::msg('clang_update'), 'save') . ' value="1">' . I18n::msg('clang_update') . '</button></td>
+                        <td class="rex-table-action" colspan="2"><button class="btn btn-save" type="submit" name="edit_clang_save"' . Accesskey::attributes(I18n::msg('clang_update'), 'save') . ' value="1">' . I18n::msg('clang_update') . '</button></td>
                     </tr>';
 
         // ----- EXTENSION POINT

--- a/pages/system/settings.php
+++ b/pages/system/settings.php
@@ -1,5 +1,6 @@
 <?php
 
+use Redaxo\Core\Backend\Accesskey;
 use Redaxo\Core\Cache;
 use Redaxo\Core\Content\Article;
 use Redaxo\Core\Core;
@@ -358,7 +359,7 @@ $content .= $fragment->parse('core/form/form.php');
 $formElements = [];
 
 $n = [];
-$n['field'] = '<button class="btn btn-save rex-form-aligned" type="submit" name="sendit"' . Core::getAccesskey(I18n::msg('system_update'), 'save') . '>' . I18n::msg('system_update') . '</button>';
+$n['field'] = '<button class="btn btn-save rex-form-aligned" type="submit" name="sendit"' . Accesskey::attributes(I18n::msg('system_update'), 'save') . '>' . I18n::msg('system_update') . '</button>';
 $formElements[] = $n;
 
 $fragment = new Fragment();

--- a/pages/user/roles.php
+++ b/pages/user/roles.php
@@ -1,5 +1,6 @@
 <?php
 
+use Redaxo\Core\Backend\Accesskey;
 use Redaxo\Core\Backend\Controller;
 use Redaxo\Core\Core;
 use Redaxo\Core\Database\Sql;
@@ -47,7 +48,7 @@ if ('' == $func) {
     $list->addTableAttribute('class', 'table-striped table-hover');
 
     $tdIcon = '<i class="rex-icon rex-icon-userrole"></i>';
-    $thIcon = '<a class="rex-link-expanded" href="' . $list->getUrl(['func' => 'add', 'default_value' => 1]) . '"' . Core::getAccesskey(I18n::msg('create_user_role'), 'add') . ' title="' . I18n::msg('create_user_role') . '"><i class="rex-icon rex-icon-add-userrole"></i></a>';
+    $thIcon = '<a class="rex-link-expanded" href="' . $list->getUrl(['func' => 'add', 'default_value' => 1]) . '"' . Accesskey::attributes(I18n::msg('create_user_role'), 'add') . ' title="' . I18n::msg('create_user_role') . '"><i class="rex-icon rex-icon-add-userrole"></i></a>';
     $list->addColumn($thIcon, $tdIcon, 0, ['<th class="rex-table-icon">###VALUE###</th>', '<td class="rex-table-icon">###VALUE###</td>']);
     $list->setColumnParams($thIcon, ['func' => 'edit', 'id' => '###id###']);
 

--- a/pages/user/roles.php
+++ b/pages/user/roles.php
@@ -48,7 +48,7 @@ if ('' == $func) {
     $list->addTableAttribute('class', 'table-striped table-hover');
 
     $tdIcon = '<i class="rex-icon rex-icon-userrole"></i>';
-    $thIcon = '<a class="rex-link-expanded" href="' . $list->getUrl(['func' => 'add', 'default_value' => 1]) . '"' . Accesskey::attributes(I18n::msg('create_user_role'), 'add') . ' title="' . I18n::msg('create_user_role') . '"><i class="rex-icon rex-icon-add-userrole"></i></a>';
+    $thIcon = '<a class="rex-link-expanded" href="' . $list->getUrl(['func' => 'add', 'default_value' => 1]) . '"' . Accesskey::attributes(I18n::msg('create_user_role'), 'add') . '><i class="rex-icon rex-icon-add-userrole"></i></a>';
     $list->addColumn($thIcon, $tdIcon, 0, ['<th class="rex-table-icon">###VALUE###</th>', '<td class="rex-table-icon">###VALUE###</td>']);
     $list->setColumnParams($thIcon, ['func' => 'edit', 'id' => '###id###']);
 

--- a/pages/user/users.php
+++ b/pages/user/users.php
@@ -1,6 +1,7 @@
 <?php
 
 use Redaxo\Core\ApiFunction\ApiFunction;
+use Redaxo\Core\Backend\Accesskey;
 use Redaxo\Core\Backend\Controller;
 use Redaxo\Core\Core;
 use Redaxo\Core\Database\Sql;
@@ -341,11 +342,11 @@ if ('' != $fUNCADD || $user) {
         $formElements[] = $n;
 
         $n = [];
-        $n['field'] = '<button class="btn btn-save rex-form-aligned" type="submit" name="FUNC_UPDATE" value="1" ' . Core::getAccesskey(I18n::msg('save_and_close_tooltip'), 'save') . '>' . I18n::msg('user_save') . '</button>';
+        $n['field'] = '<button class="btn btn-save rex-form-aligned" type="submit" name="FUNC_UPDATE" value="1" ' . Accesskey::attributes(I18n::msg('save_and_close_tooltip'), 'save') . '>' . I18n::msg('user_save') . '</button>';
         $formElements[] = $n;
 
         $n = [];
-        $n['field'] = '<button class="btn btn-apply" type="submit" name="FUNC_APPLY" value="1" ' . Core::getAccesskey(I18n::msg('save_and_goon_tooltip'), 'apply') . '>' . I18n::msg('user_apply') . '</button>';
+        $n['field'] = '<button class="btn btn-apply" type="submit" name="FUNC_APPLY" value="1" ' . Accesskey::attributes(I18n::msg('save_and_goon_tooltip'), 'apply') . '>' . I18n::msg('user_apply') . '</button>';
         $formElements[] = $n;
 
         $fragment = new Fragment();
@@ -419,7 +420,7 @@ if ('' != $fUNCADD || $user) {
         $formElements = [];
 
         $n = [];
-        $n['field'] = '<button class="btn btn-save" type="submit" name="function" value="1" ' . Core::getAccesskey(I18n::msg('add_user'), 'save') . '>' . I18n::msg('add_user') . '</button>';
+        $n['field'] = '<button class="btn btn-save" type="submit" name="function" value="1" ' . Accesskey::attributes(I18n::msg('add_user'), 'save') . '>' . I18n::msg('add_user') . '</button>';
         $formElements[] = $n;
 
         $fragment = new Fragment();
@@ -614,7 +615,7 @@ if ($SHOW) {
     $list->addTableAttribute('class', 'table-striped table-hover');
 
     $tdIcon = '<i class="rex-icon rex-icon-user" title="' . I18n::msg('user_status_active') . '"></i>';
-    $thIcon = '<a class="rex-link-expanded" href="' . $list->getUrl(['FUNC_ADD' => '1']) . '"' . Core::getAccesskey(I18n::msg('create_user'), 'add') . ' title="' . I18n::msg('create_user') . '"><i class="rex-icon rex-icon-add-user"></i></a>';
+    $thIcon = '<a class="rex-link-expanded" href="' . $list->getUrl(['FUNC_ADD' => '1']) . '"' . Accesskey::attributes(I18n::msg('create_user'), 'add') . ' title="' . I18n::msg('create_user') . '"><i class="rex-icon rex-icon-add-user"></i></a>';
     $list->addColumn($thIcon, $tdIcon, 0, ['<th class="rex-table-icon">###VALUE###</th>', '<td class="rex-table-icon">###VALUE###</td>']);
     $list->setColumnParams($thIcon, ['user_id' => '###id###']);
     $list->setColumnFormat($thIcon, 'custom', static function () use ($currentUser, $list, $thIcon, $tdIcon) {

--- a/pages/user/users.php
+++ b/pages/user/users.php
@@ -615,7 +615,7 @@ if ($SHOW) {
     $list->addTableAttribute('class', 'table-striped table-hover');
 
     $tdIcon = '<i class="rex-icon rex-icon-user" title="' . I18n::msg('user_status_active') . '"></i>';
-    $thIcon = '<a class="rex-link-expanded" href="' . $list->getUrl(['FUNC_ADD' => '1']) . '"' . Accesskey::attributes(I18n::msg('create_user'), 'add') . ' title="' . I18n::msg('create_user') . '"><i class="rex-icon rex-icon-add-user"></i></a>';
+    $thIcon = '<a class="rex-link-expanded" href="' . $list->getUrl(['FUNC_ADD' => '1']) . '"' . Accesskey::attributes(I18n::msg('create_user'), 'add') . '><i class="rex-icon rex-icon-add-user"></i></a>';
     $list->addColumn($thIcon, $tdIcon, 0, ['<th class="rex-table-icon">###VALUE###</th>', '<td class="rex-table-icon">###VALUE###</td>']);
     $list->setColumnParams($thIcon, ['user_id' => '###id###']);
     $list->setColumnFormat($thIcon, 'custom', static function () use ($currentUser, $list, $thIcon, $tdIcon) {

--- a/schemas/config.json
+++ b/schemas/config.json
@@ -263,18 +263,6 @@
                 }
             },
             "additionalProperties": false
-        },
-        "use_accesskeys": {
-            "description": "Whether the accesskeys should be used",
-            "type": "boolean"
-        },
-        "accesskeys": {
-            "description": "Access keys",
-            "type": "object",
-            "additionalProperties": {
-                "type": "string",
-                "pattern": "^[a-z]$"
-            }
         }
     },
     "additionalProperties": false

--- a/setup/default.config.yml
+++ b/setup/default.config.yml
@@ -65,10 +65,3 @@ db:
         ssl_cert: null
         ssl_ca: null
         ssl_verify_server_cert: true
-use_accesskeys: true
-accesskeys:
-    save: s
-    apply: x
-    delete: d
-    add: a
-    add_2: y

--- a/src/Backend/Accesskey.php
+++ b/src/Backend/Accesskey.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Redaxo\Core\Backend;
+
+use function array_key_exists;
+
+/** Accesskeys of the backend, keyboard shortcuts for the most common actions. */
+final class Accesskey
+{
+    public static bool $enabled = true;
+
+    /** @var array<string, string> */
+    public static array $keys = [
+        'save' => 's',
+        'apply' => 'x',
+        'delete' => 'd',
+        'add' => 'a',
+        'add_2' => 'y',
+    ];
+
+    private function __construct() {}
+
+    /**
+     * Returns the title attribute for an element, including the accesskey attribute if the given key has one.
+     *
+     * @return non-empty-string
+     */
+    public static function attributes(string $title, string $key): string
+    {
+        if (self::$enabled && array_key_exists($key, self::$keys)) {
+            $accesskey = self::$keys[$key];
+
+            return ' accesskey="' . $accesskey . '" title="' . $title . ' [' . $accesskey . ']"';
+        }
+
+        return ' title="' . $title . '"';
+    }
+}

--- a/src/Content/ArticleContentEditor.php
+++ b/src/Content/ArticleContentEditor.php
@@ -3,6 +3,7 @@
 namespace Redaxo\Core\Content;
 
 use Override;
+use Redaxo\Core\Backend\Accesskey;
 use Redaxo\Core\Backend\Controller;
 use Redaxo\Core\Content\ApiFunction\ArticleSliceMove;
 use Redaxo\Core\Content\ApiFunction\ArticleSliceStatusChange;
@@ -411,7 +412,7 @@ final class ArticleContentEditor extends ArticleContentBase
         $formElements[] = $n;
 
         $n = [];
-        $n['field'] = '<button class="btn btn-save" type="submit" name="btn_save" value="1"' . Core::getAccesskey(I18n::msg('add_block'), 'save') . '>' . I18n::msg('add_block') . '</button>';
+        $n['field'] = '<button class="btn btn-save" type="submit" name="btn_save" value="1"' . Accesskey::attributes(I18n::msg('add_block'), 'save') . '>' . I18n::msg('add_block') . '</button>';
         $formElements[] = $n;
 
         $fragment = new Fragment();
@@ -466,11 +467,11 @@ final class ArticleContentEditor extends ArticleContentBase
         $formElements[] = $n;
 
         $n = [];
-        $n['field'] = '<button class="btn btn-save" type="submit" name="btn_save" value="1"' . Core::getAccesskey(I18n::msg('save_and_close_tooltip'), 'save') . '>' . I18n::msg('save_block') . '</button>';
+        $n['field'] = '<button class="btn btn-save" type="submit" name="btn_save" value="1"' . Accesskey::attributes(I18n::msg('save_and_close_tooltip'), 'save') . '>' . I18n::msg('save_block') . '</button>';
         $formElements[] = $n;
 
         $n = [];
-        $n['field'] = '<button class="btn btn-apply" type="submit" name="btn_update" value="1"' . Core::getAccesskey(I18n::msg('save_and_goon_tooltip'), 'apply') . '>' . I18n::msg('update_block') . '</button>';
+        $n['field'] = '<button class="btn btn-apply" type="submit" name="btn_update" value="1"' . Accesskey::attributes(I18n::msg('save_and_goon_tooltip'), 'apply') . '>' . I18n::msg('update_block') . '</button>';
         $formElements[] = $n;
 
         $fragment = new Fragment();

--- a/src/Core.php
+++ b/src/Core.php
@@ -148,8 +148,6 @@ final class Core
      *
      * @return (
      *      $key is 'login' ? BackendLogin|null :
-     *      ($key is 'use_accesskeys' ? bool :
-     *      ($key is 'accesskeys' ? array<string, string> :
      *      ($key is 'timer' ? Timer :
      *      ($key is 'server' ? string :
      *      ($key is 'servername' ? string :
@@ -160,7 +158,7 @@ final class Core
      *      ($key is 'setup' ? bool|array<string, int> :
      *      ($key is 'setup_addons' ? non-empty-string[] :
      *      mixed|null
-     *      ))))))))))))
+     *      ))))))))))
      * ) The value for $key or $default if $key cannot be found
      */
     public static function getProperty(string $key, mixed $default = null): mixed
@@ -459,25 +457,6 @@ final class Core
             return Formatter::version($version, $format);
         }
         return $version;
-    }
-
-    /**
-     * Returns the title tag and if the property "use_accesskeys" is true, the accesskey tag.
-     *
-     * @param string $title Title
-     * @param string $key Key for the accesskey
-     * @return non-empty-string
-     */
-    public static function getAccesskey(string $title, string $key): string
-    {
-        if (self::getProperty('use_accesskeys')) {
-            $accesskeys = (array) self::getProperty('accesskeys', []);
-            if (isset($accesskeys[$key])) {
-                return ' accesskey="' . $accesskeys[$key] . '" title="' . $title . ' [' . $accesskeys[$key] . ']"';
-            }
-        }
-
-        return ' title="' . $title . '"';
     }
 
     /** @internal */

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -2,6 +2,7 @@
 
 namespace Redaxo\Core\View;
 
+use Redaxo\Core\Backend\Accesskey;
 use Redaxo\Core\Backend\Controller;
 use Redaxo\Core\Backend\Navigation;
 use Redaxo\Core\Backend\Page;
@@ -272,7 +273,7 @@ final class View
 
         $addSubmit = '';
         if ($closeForm && '' != $openerInputField) {
-            $addSubmit = '<button class="btn btn-save" type="submit" name="saveandexit" value="' . I18n::msg('pool_file_upload_get') . '"' . Core::getAccesskey(I18n::msg('save_and_close_tooltip'), 'save') . '>' . I18n::msg('pool_file_upload_get') . '</button>';
+            $addSubmit = '<button class="btn btn-save" type="submit" name="saveandexit" value="' . I18n::msg('pool_file_upload_get') . '"' . Accesskey::attributes(I18n::msg('save_and_close_tooltip'), 'save') . '>' . I18n::msg('pool_file_upload_get') . '</button>';
         }
 
         $panel = '';
@@ -315,7 +316,7 @@ final class View
         $formElements = [];
 
         $e = [];
-        $e['field'] = '<button class="btn btn-save rex-form-aligned" type="submit" name="save" value="' . $buttonTitle . '"' . Core::getAccesskey($buttonTitle, 'save') . '>' . $buttonTitle . '</button>';
+        $e['field'] = '<button class="btn btn-save rex-form-aligned" type="submit" name="save" value="' . $buttonTitle . '"' . Accesskey::attributes($buttonTitle, 'save') . '>' . $buttonTitle . '</button>';
         $formElements[] = $e;
 
         $e = [];


### PR DESCRIPTION
Removes `use_accesskeys` and `accesskeys` from the `config.yml`. The accesskeys stay a feature, they are configured in code now.

```php
Accesskey::$enabled = true;
Accesskey::$keys = ['save' => 's', 'apply' => 'x', 'delete' => 'd', 'add' => 'a', 'add_2' => 'y'];
Accesskey::attributes($title, 'save');   // was Core::getAccesskey()
```

`Core::getAccesskey()` moves along, since it is the one bit of logic that belongs with the settings ("only if enabled, and only if the key has an accesskey defined"). That is 29 call sites in `pages/`, `src/View/View.php` and `src/Content/ArticleContentEditor.php`, plus the js property in `boot/backend.php`. The name says what it returns: the title attribute, plus the accesskey attribute when there is one.

### Why not in `Backend\Appearance`

It would put the backend settings in one place, which is tempting. But accesskeys are input, not appearance — `Appearance` currently has a sharp meaning (theme, instance color), and widening it to "backend settings" would rebuild the grab-bag we are taking apart in `Core`. The next unrelated setting would land there too, for lack of a better reason than the name.
