### PR TITLE
fix: avoid "No clang found" when the clang cache is deleted by a parallel request

### DIFF
--- a/redaxo/src/core/lib/clang/clang.php
+++ b/redaxo/src/core/lib/clang/clang.php
@@ -243,10 +243,14 @@ class rex_clang
         }
 
         $file = rex_path::coreCache('clang.cache');
-        if (!is_file($file)) {
-            rex_clang_service::generateCache();
+        $cache = rex_file::getCache($file);
+
+        // deliberately no is_file() check: a parallel cache clear could delete the file between check and read
+        if (!$cache) {
+            $cache = rex_clang_service::generateCache();
         }
-        foreach (rex_file::getCache($file) as $id => $data) {
+
+        foreach ($cache as $id => $data) {
             $clang = new self();
             $clang->id = (int) $id;
             $clang->priority = (int) $data['priority'];

--- a/redaxo/src/core/lib/clang/service.php
+++ b/redaxo/src/core/lib/clang/service.php
@@ -127,7 +127,7 @@ class rex_clang_service
      * Schreibt Spracheigenschaften in die Datei include/clang.php.
      *
      * @throws rex_exception
-     * @return void
+     * @return array<int, array<string, scalar|null>>
      */
     public static function generateCache()
     {
@@ -146,5 +146,7 @@ class rex_clang_service
         if (!rex_file::putCache($file, $clangs)) {
             throw new rex_exception('Clang cache file could not be generated');
         }
+
+        return $clangs;
     }
 }


### PR DESCRIPTION
Fixes #6648

## Problem

`rex_clang::checkCache()` used a check-then-read pattern:

```php
if (!is_file($file)) {
    rex_clang_service::generateCache();
}
foreach (rex_file::getCache($file) as $id => $data) {
```

`rex_delete_cache()` wipes the whole cache directory. If that happens between the `is_file()` check and the read, `file_get_contents()` fails, `rex_file::getCache()` returns its empty default `[]` — and `checkCache()` still sets `cacheLoaded = true`. The request then runs with zero languages.

The visible symptom is `LogicException: No clang found.` from `getStartId()`, which `boot.php` evaluates on nearly every request (`rex_request('clang', 'int', rex_clang::getStartId())`) — hence the reports of the error hitting completely unrelated pages. Less visible, but worse: `exists()`, `get()` and `getAll()` silently return wrong results in the same situation.

Note that the "reading while another request writes" theory from the issue does not apply — `rex_file::put()` already writes atomically via `tempnam()` + `rename()`.

## Fix

Read the file first and fall back to a freshly generated cache when the result is empty. `rex_clang_service::generateCache()` now returns the data it generated, so the fallback does not read the file back from disk and cannot lose the same race a second time. This mirrors the read-first pattern already used by mediapool and structure.

As a side effect, an empty or truncated cache file no longer leads to `foreach` over `null`.

The exception in `getStartId()` still fires when the `clang` table really is empty.

## Compatibility

`generateCache()` gained a return value (previously `@return void`); callers are unaffected.

## Testing

- Manually verified with a deleted and with a truncated `clang.cache`: the cache is regenerated and the languages load correctly.
- `composer phpstan`, `composer psalm`, `composer cs` clean; no baseline changes.