### PR TITLE
test: wait for lazy loaded images before taking visual test screenshots

### DIFF
--- a/.tools/visual-tests/visual-record.js
+++ b/.tools/visual-tests/visual-record.js
@@ -167,6 +167,17 @@ async function processScreenshot(page, screenshotName) {
         });
     });
 
+    // images with `loading="lazy"` do not delay the load event, and `fullPage` screenshots don't scroll them into
+    // view either. Load them eagerly and wait until every image is decoded, otherwise slow ones (media manager
+    // thumbnails) randomly end up missing in the screenshot.
+    await page.evaluate(() => {
+        for (const img of document.images) {
+            img.loading = 'eager';
+        }
+    });
+    await page.waitForFunction(() => [...document.images].every((img) => img.complete), null, { timeout: 30000 });
+    await page.evaluate(() => Promise.all([...document.images].map((img) => img.decode().catch(() => {}))));
+
     await page.screenshot({ path: WORKING_DIR + screenshotName, fullPage: true, animations: 'disabled' });
 
     // make sure we only create changes in .tools/visual-tests/screenshots/ on substential screenshot changes.


### PR DESCRIPTION
The mediapool thumbnail in `mediapool/pages/media.list.php` is rendered with `loading="lazy"` — and lazy images do not delay the load event, which is what the recorder navigates with (`waitUntil: 'load'`). The image itself comes from the media manager and has to be generated on the first request, so whether it made it into the screenshot was a race.

That is what keeps rewriting `mediapool_media.png`, e.g. in #6655: one commit sets light + dark to "no thumbnail", the next one puts dark back, the one after that light. Light and dark are taken from a single page load one after the other, so the image simply arrived in between. Since `MIN_DIFF_PIXELS = 1` commits any pixel difference as the new golden sample, the auto-commit then retriggers the workflow and it keeps swinging.

Reproduced in isolation with a deliberately slow image response:

```
with loading="lazy":     after load event, t=  70ms  [{"complete":false,"w":0}]
without loading="lazy":  after load event, t=1548ms  [{"complete":true,"w":1200}]
```

### The fix

Before each screenshot, all images are switched to eager and awaited:

* `loading = 'eager'` is what gets a lazy image to load at all — a `fullPage` screenshot doesn't scroll it into view either, so images below the fold would never have loaded.
* `waitForFunction` waits with a real timeout, so a permanently stuck image fails the action instead of hanging it for 30 minutes.
* `decode()` closes the remaining gap between "loaded" and "decoded for the next paint".

`loading="lazy"` appears in exactly those two thumbnail lines in the whole backend, so nothing else is affected.

The first run with this may still commit a golden sample once — namely if the current one happens to be stuck in a "no thumbnail" state. That's the last correction, not the next swing.

Noticed on `6.x`, where the media manager rebuild (#6566) makes generating the image slow enough for the race to tip the wrong way more often. The cause is the same here, so this is meant to be merged up.