### PR TITLE
refactor!: configure the session lifetime as a policy object

### DIFF
--- a/.tools/psalm/baseline.xml
+++ b/.tools/psalm/baseline.xml
@@ -2393,7 +2393,6 @@
     </MixedArrayAccess>
     <MixedAssignment>
       <code><![CDATA[$sessionConfig]]></code>
-      <code><![CDATA[$this->sessionDuration]]></code>
     </MixedAssignment>
     <PossiblyInvalidArrayOffset>
       <code><![CDATA[$_SESSION[static::getSessionNamespace()]]]></code>
@@ -2430,7 +2429,6 @@
     </MixedArrayAssignment>
     <MixedAssignment>
       <code><![CDATA[$rexSessId]]></code>
-      <code><![CDATA[$this->sessionMaxOverallDuration]]></code>
     </MixedAssignment>
     <MixedReturnStatement>
       <code><![CDATA[$_SESSION[static::getSessionNamespace()][$this->systemId][$varname] ?? $default]]></code>

--- a/boot/backend.php
+++ b/boot/backend.php
@@ -236,12 +236,13 @@ if (Core::getUser()) {
     Asset::setJsProperty('session_keep_alive_url', Url::backendController(['page' => 'credits', 'rex-api-call' => 'user_session_status']));
     Asset::setJsProperty('session_logout_url', Url::backendController(['rex_logout' => 1] + CsrfToken::factory('backend_logout')->getUrlParams()));
     Asset::setJsProperty('session_login_url', Url::backendController());
-    Asset::setJsProperty('session_keep_alive', Core::getProperty('session_keep_alive', 0));
-    Asset::setJsProperty('session_duration', Core::getProperty('session_duration', 0));
-    Asset::setJsProperty('session_max_overall_duration', Core::getProperty('session_max_overall_duration', 0));
+    $sessionPolicy = BackendLogin::getSessionPolicy();
+    Asset::setJsProperty('session_keep_alive', $sessionPolicy->keepAlive);
+    Asset::setJsProperty('session_duration', $sessionPolicy->duration);
+    Asset::setJsProperty('session_max_overall_duration', $sessionPolicy->maxOverallDuration);
     Asset::setJsProperty('session_start', $login->getSessionVar(Login::SESSION_START_TIME));
     Asset::setJsProperty('session_stay_logged_in', $login->getSessionVar(BackendLogin::SESSION_STAY_LOGGED_IN, false));
-    Asset::setJsProperty('session_warning_time', Core::getProperty('session_warning_time', 300));
+    Asset::setJsProperty('session_warning_time', $sessionPolicy->warningTime);
     Asset::setJsProperty('session_server_time', time());
 
     Asset::setJsProperty('i18n', [

--- a/schemas/config.json
+++ b/schemas/config.json
@@ -40,22 +40,6 @@
             "type": ["null", "string"],
             "format": "email"
         },
-        "session_duration": {
-            "description": "A Session will be closed when not activly used for this timespan (seconds)",
-            "type": "integer"
-        },
-        "session_keep_alive": {
-            "description": "A open browser window will auto extended the session for this timespan (seconds)",
-            "type": "integer"
-        },
-        "session_max_overall_duration": {
-            "description": "A session cannot stay longer then this value, no matter its actively used once in a while (seconds)",
-            "type": "integer"
-        },
-        "session_warning_time": {
-            "description": "Seconds before a dialog window appears and asks for action",
-            "type": "integer"
-        },
         "session": {
             "description": "Session configuration",
             "type": "object",

--- a/setup/default.config.yml
+++ b/setup/default.config.yml
@@ -2,10 +2,6 @@ setup: true
 server: https://www.redaxo.org/
 servername: REDAXO
 error_email: null
-session_duration: 7200
-session_keep_alive: 21600
-session_max_overall_duration: 2419200 # 4 weeks
-session_warning_time: 300
 # using separate cookie domains for frontend and backend is more secure,
 # but be warned that some features like detecting a backend user in the frontend
 # will no longer work.

--- a/src/Content/HistoryLogin.php
+++ b/src/Content/HistoryLogin.php
@@ -33,7 +33,7 @@ final class HistoryLogin extends BackendLogin
                 WHERE user_id = ? AND UNIX_TIMESTAMP(last_activity) >= IF(cookie_key IS NULL, ?, ?)',
             [
                 (int) $userSql->getValue($this->idColumn),
-                time() - (int) Core::getProperty('session_duration'),
+                time() - BackendLogin::getSessionPolicy()->duration,
                 strtotime('-' . UserSession::STAY_LOGGED_IN_DURATION . ' months'),
             ],
         );

--- a/src/Security/ApiFunction/UserSessionStatus.php
+++ b/src/Security/ApiFunction/UserSessionStatus.php
@@ -27,7 +27,7 @@ final class UserSessionStatus extends ApiFunction
 
         $login = Core::getProperty('login');
 
-        $restOverallTime = (int) Core::getProperty('session_max_overall_duration', 0) + (int) $login->getSessionVar(BackendLogin::SESSION_START_TIME) - (int) $login->getSessionVar(BackendLogin::SESSION_LAST_ACTIVITY);
+        $restOverallTime = BackendLogin::getSessionPolicy()->maxOverallDuration + (int) $login->getSessionVar(BackendLogin::SESSION_START_TIME) - (int) $login->getSessionVar(BackendLogin::SESSION_LAST_ACTIVITY);
         Response::sendJson([
             'rest_overall_time' => $restOverallTime,
         ]);

--- a/src/Security/BackendLogin.php
+++ b/src/Security/BackendLogin.php
@@ -37,6 +37,9 @@ class BackendLogin extends Login
     /** Policy for the passwords of backend users. */
     public static ?BackendPasswordPolicy $passwordPolicy = null;
 
+    /** Policy for the lifetime of a backend session. */
+    public static ?SessionPolicy $sessionPolicy = null;
+
     private static ?string $legacySha1Hash = null;
 
     private readonly string $tableName;
@@ -49,7 +52,9 @@ class BackendLogin extends Login
 
         $tableName = Core::getTablePrefix() . 'user';
         $this->systemId = self::SYSTEM_ID;
-        $this->sessionDuration = Core::getProperty('session_duration');
+        $sessionPolicy = self::getSessionPolicy();
+        $this->sessionDuration = $sessionPolicy->duration;
+        $this->sessionMaxOverallDuration = $sessionPolicy->maxOverallDuration;
         $qry = 'SELECT * FROM ' . $tableName;
         $this->userQuery = $qry . ' WHERE id = :id AND status = 1';
         $this->impersonateQuery = $qry . ' WHERE id = :id';
@@ -373,6 +378,11 @@ class BackendLogin extends Login
     public static function getPasswordPolicy(): BackendPasswordPolicy
     {
         return self::$passwordPolicy ??= new BackendPasswordPolicy();
+    }
+
+    public static function getSessionPolicy(): SessionPolicy
+    {
+        return self::$sessionPolicy ??= new SessionPolicy();
     }
 
     /**

--- a/src/Security/Login.php
+++ b/src/Security/Login.php
@@ -42,7 +42,8 @@ class Login
     /** A Session will be closed when not activly used for this timespan (seconds). */
     protected int $sessionDuration = 0;
     /** A session cannot stay longer then this value, no matter its actively used once in a while (seconds). */
-    protected int $sessionMaxOverallDuration;
+    /** Overridden by `BackendLogin` from its session policy, other logins set their own value. */
+    protected int $sessionMaxOverallDuration = 2_419_200; // 4 weeks
 
     protected string $loginQuery;
     protected string $userQuery;
@@ -66,8 +67,6 @@ class Login
 
     public function __construct()
     {
-        $this->sessionMaxOverallDuration = Core::getProperty('session_max_overall_duration', 2_419_200); // 4 weeks
-
         self::startSession();
     }
 

--- a/src/Security/SessionPolicy.php
+++ b/src/Security/SessionPolicy.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Redaxo\Core\Security;
+
+/** Policy for the lifetime of a backend session, configured by the project. */
+final readonly class SessionPolicy
+{
+    /**
+     * @param int $duration Seconds of inactivity after which the session is closed
+     * @param int $keepAlive Seconds an open browser window extends the session for, `0` to disable
+     * @param int $maxOverallDuration Seconds a session can last at most, no matter how actively it is used
+     * @param int $warningTime Seconds before the session expires, at which the user is warned
+     */
+    public function __construct(
+        public int $duration = 7200,
+        public int $keepAlive = 21600,
+        public int $maxOverallDuration = 2_419_200,
+        public int $warningTime = 300,
+    ) {}
+}

--- a/src/Security/UserSession.php
+++ b/src/Security/UserSession.php
@@ -117,7 +117,7 @@ final class UserSession
         Sql::factory()
             ->setTable(Core::getTable('user_session'))
             ->setWhere('UNIX_TIMESTAMP(last_activity) < IF(cookie_key IS NULL, ?, ?)', [
-                time() - (int) Core::getProperty('session_duration'),
+                time() - BackendLogin::getSessionPolicy()->duration,
                 strtotime('-' . self::STAY_LOGGED_IN_DURATION . ' months'),
             ])
             ->delete();


### PR DESCRIPTION
Removes `session_duration`, `session_keep_alive`, `session_max_overall_duration` and `session_warning_time` from the `config.yml`. They describe one thing — how long a backend session lives and when the user gets warned — so they become one object, next to the two policies that moved in #6655:

```php
BackendLogin::$sessionPolicy = new SessionPolicy(duration: 1800, warningTime: 60);
```

`keepAlive` and `warningTime` are only handed to the backend js; `duration` and `maxOverallDuration` are additionally used by `BackendLogin`, `UserSession`, `HistoryLogin` and the session status api function.

### The base class stops reading global config

`Login::__construct()` read `session_max_overall_duration` — and `Login` is the base class for frontend logins too, which therefore silently inherited the backend's limit. The property now carries the four weeks as its default, and `BackendLogin` sets both durations from its policy.

**This is a behaviour change**: a project that configured `session_max_overall_duration` also affected addon frontend logins until now. Those fall back to the default; a login outside the backend that wants its own limit sets `$sessionMaxOverallDuration` on its own class.

### No validation

Unlike `LoginPolicy`, which rejects zeros because a zero silently locks everyone out of the backend, `SessionPolicy` takes the values as they are: `keepAlive: 0` is a meaningful "no keep alive", and the js treats it that way.

### Not in here

`session.*` — the cookie parameters and the save path — stays for now. It is the block that should be answered together with issue #2065 (`Login::startSession()` implies a login) and with the question whether the session mechanics move onto `symfony/http-foundation`'s session, which is already a direct dependency and whose `NativeSessionStorage` takes exactly these options. Migrating that block into a REDAXO object first would mean migrating projects twice.

### Verified

The four values reach `rex.session_*` in the backend js, both with the defaults and with a project policy (`duration: 900, keepAlive: 0, warningTime: 60`), and the session status api reports `rest_overall_time` from the configured `maxOverallDuration`.
